### PR TITLE
Added tmpPath variable for linux agents

### DIFF
--- a/marketplace.md
+++ b/marketplace.md
@@ -51,6 +51,13 @@ Run a specific version of tfsec.
   inputs:
     dir: ./terraform
 ```
+### Specify the directory to download tfsec binnary and store resuls files on Linux agents, Default is /tmp/
+
+```yaml
+- task: tfsec@1
+  inputs:
+    tmpPath: /tmp/
+```
 
 ### Skip publishing test results
 

--- a/tfsec-task/index.ts
+++ b/tfsec-task/index.ts
@@ -8,7 +8,7 @@ async function run() {
     try {
         console.log("Finding correct tfsec version...")
         let url = await getArtifactURL()
-        let tmpPath = "/tmp/"
+        let tmpPath = task.getInput("tmpPath", true)
         let bin = "tfsec"
         let chmodRequired = true;
         if (os.platform() == "win32") {

--- a/tfsec-task/task.json
+++ b/tfsec-task/task.json
@@ -49,6 +49,14 @@
             "defaultValue": "",
             "required": false,
             "helpMarkDown": "The specified directory will be scanned for problems"
+        },
+        {
+            "name": "tmpPath",
+            "type": "string",
+            "label": "The directory to download tfsec and store results files on Linux agents",
+            "defaultValue": "/tmp/",
+            "required": false,
+            "helpMarkDown": "The specified directory will used to download tfsec binary and store results files on Linux agents"
         }
     ],
     "execution": {


### PR DESCRIPTION
Adding this parameterized tmpPath argument will let us specify tmpPath locattion to download results and tfsec binary to anyother directory. Needed to hardned OS  agents #20 